### PR TITLE
updating swift_version

### DIFF
--- a/keyboardSwitcher.xcodeproj/project.pbxproj
+++ b/keyboardSwitcher.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "keyboardSwitcher/Core/keyboardSwitcher-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -308,7 +308,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "keyboardSwitcher/Core/keyboardSwitcher-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
`brew install keyboard-switcher` fails using latest xcode and tools: 

```
Last 15 lines from /Users/mark/Library/Logs/Homebrew/keyboardswitcher/01.xcodebuild:
2019-04-12 10:23:39 +0100

xcodebuild

note: Using new build system
note: Planning build
note: Constructing build description
Build system information
error: SWIFT_VERSION '3.0' is unsupported, supported versions are: 4.0, 4.2, 5.0. (in target 'keyboardSwitcher')

** BUILD FAILED **
```

Setting `SWIFT_VERSION = 5.0` allows xcodebuild to complete successfully.