### PR TITLE
Add layout enable/disable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@
 - **select "\<layout\>:** Set the current keyboard layout.
 - **get:** Retrieve the currently active keyboard layout.
 - **version:** Print the version of `keyboardSwitcher`.
+- **enable "\<layout\>:** Enable a layout so it can then be selected.
+- **disable "\<layout\>:** Disable a layout so it can no longer be selected.
 
 ## Limitations
 
-To successfully execute the "select" command, the desired keyboard layout must be added in the macOS Settings app under Keyboard > Sources.
+To successfully execute the `select` command, the desired keyboard layout must first be enabled.
+This can be achieved by:
+- adding the layout in the macOS Settings app under Keyboard > Sources.
+
+OR
+
+- using the `enable` command
 
 ## Possible Usages
 
@@ -97,4 +105,54 @@ Output:
 U.S.
 ```
 
+### Enable and set a Layout
+
+```bash
+enable British-PC
+
+```
+
+Output:
+```plaintext
+Enabling "British-PC"...
+FOUND by shortened input source id
+Successfully enabled the layout "British – PC".
+```
+<br>
+
+```bash
+select British-PC
+
+```
+
+Output:
+```plaintext
+Selecting "British-PC"...
+FOUND by shortened input source id
+Successfully set the layout "British – PC".
+```
+
+> **_NOTE:_**
+> Layouts can be referenced in three different ways. This can be convenient as some keyboard layout localised names contain non-ASCII characters such as the en dash (–).
+> - Fully qualified input source id e.g. `com.apple.keylayout.British-PC`
+> - Shortened input source id e.g. `British-PC`
+> - Localised name `"British – PC"`
+
+
+
+### Disable a Layout
+
+```bash
+disable com.apple.keylayout.British-PC
+
+```
+Output:
+```plaintext
+Disabling "com.apple.keylayout.British-PC"...
+FOUND by fully qualified input source id
+Successfully disabled the layout "British – PC".
+```
+
+
 Feel free to explore the various commands to manage your keyboard layouts efficiently.
+

--- a/Sources/CLI/CommandCenter.swift
+++ b/Sources/CLI/CommandCenter.swift
@@ -26,15 +26,38 @@ class CommandCenter {
     }
 
     func selectLayout(layout: String) {
-        print("Selecting \(layout)")
-
-        guard let selectedLayout = KeyboardManager.shared.enabledLayouts.first(where: { $0.localizedName == layout }) else {
-            print("not found")
-            return
+        print("Selecting \"\(layout)\"...")
+        if let keyboardSource = KeyboardManager.shared.findKeyboardSource(enabledOnly: true, layoutIdentifier:layout) {
+            KeyboardManager.shared.selectLayout(withSource: keyboardSource)
+        } else {
+            print("Unable to reconcile \"\(layout)\" with a KeyboardSource. May need to enable first.")
         }
-         
-        print("found")
-        KeyboardManager.shared.selectLayout(withID: selectedLayout.inputSourceID)
+    }
+    
+    func enableLayout(layout: String) {
+        print("Enabling \"\(layout)\"...")
+        if let keyboardSource = KeyboardManager.shared.findKeyboardSource(enabledOnly: false, layoutIdentifier:layout) {
+            if keyboardSource.enabled {
+                print("\"\(layout)\" is already enabled.")
+                return
+            }
+            KeyboardManager.shared.enableLayout(withSource: keyboardSource)
+        } else {
+            print("Unable to reconcile \"\(layout)\" with a KeyboardSource.")
+        }
+    }
+    
+    func disableLayout(layout: String) {
+        print("Disabling \"\(layout)\"...")
+        if let keyboardSource = KeyboardManager.shared.findKeyboardSource(enabledOnly: false, layoutIdentifier:layout) {
+            if !keyboardSource.enabled {
+                print("\"\(layout)\" is already disabled.")
+                return
+            }
+            KeyboardManager.shared.disableLayout(withSource: keyboardSource)
+        } else {
+            print("Unable to reconcile \"\(layout)\" with a KeyboardSource.")
+        }
     }
 
     func printJSON() {

--- a/Sources/CLI/CommandLineInterpreter.swift
+++ b/Sources/CLI/CommandLineInterpreter.swift
@@ -37,6 +37,10 @@ class CommandLineInterpreter {
 
         if command == CommandLineOption.select(layout: nil).command {
             CommandLineOption.select(layout: value).run()
+        } else if command == CommandLineOption.enable(layout: nil).command {
+            CommandLineOption.enable(layout: value).run()
+        } else if command == CommandLineOption.disable(layout: nil).command {
+            CommandLineOption.disable(layout: value).run()
         } else {
             interpretTwoArguments(arguments: arguments)
         }

--- a/Sources/CLI/Option.swift
+++ b/Sources/CLI/Option.swift
@@ -6,11 +6,17 @@ enum CommandLineOption {
     case get
     case select(layout: String?)
     case json
+    case enable(layout: String?)
+    case disable(layout: String?)
 
     var command: String {
         switch self {
         case .select:
             "select"
+        case .enable:
+            "enable"
+        case .disable:
+            "disable"
         default:
             String(describing: self).lowercased()
         }
@@ -31,6 +37,10 @@ enum CommandLineOption {
             "Get the current layout"
         case .select:
             "Set the layout. Arguments: <layout name>"
+        case .enable:
+            "Enable a layout. Arguments: <layout name>"
+        case .disable:
+            "Disable a layout. Arguments: <layout name>"
         case .json:
             "List enabled layouts as Alfred-compatible JSON"
         }
@@ -58,12 +68,20 @@ enum CommandLineOption {
             if let layout = layout {
                 commandCenter.selectLayout(layout: layout)
             }
+        case .enable(let layout):
+            if let layout = layout {
+                commandCenter.enableLayout(layout: layout)
+            }
+        case .disable(let layout):
+            if let layout = layout {
+                commandCenter.disableLayout(layout: layout)
+            }
         case .get:
             commandCenter.printLayout()
         }
     }
 
     static var all: [CommandLineOption] {
-        [.list, .enabled, .version, .help, .select(layout: nil), .json]
+        [.list, .enabled, .version, .help, .select(layout: nil), .json, .enable(layout: nil), .disable(layout: nil)]
     }
 }

--- a/Sources/Core/KeyboardManager.swift
+++ b/Sources/Core/KeyboardManager.swift
@@ -11,6 +11,28 @@ class KeyboardManager {
     var enabledLayouts: [KeyboardSource] {
         sourceList(includeAllInstalled: false).filter { $0.enabled }
     }
+    
+    func findKeyboardSource(enabledOnly: Bool, layoutIdentifier: String) -> KeyboardSource? {
+        let eligibleSources: [KeyboardSource] = enabledOnly ? enabledLayouts : keyboardLayouts
+        
+        if let foundLayout = eligibleSources.first(where: { $0.inputSourceID == layoutIdentifier }) {
+            print("FOUND by fully qualified input source id")
+            return foundLayout
+        }
+
+        if let foundLayout = eligibleSources.first(where: { $0.inputSourceID.components(separatedBy: ".").last == layoutIdentifier }) {
+            print("FOUND by shortened input source id")
+            return foundLayout
+        }
+
+        if let foundLayout = eligibleSources.first(where: { $0.localizedName == layoutIdentifier }) {
+            print("FOUND by localized name")
+            return foundLayout
+        }
+
+        print("No keyboard source found for \"\(layoutIdentifier)\".")
+        return nil
+    }
 
     var currentKeyboardLayout: KeyboardSource {
         KeyboardSource(source: TISCopyCurrentKeyboardInputSource().takeRetainedValue())

--- a/Sources/Core/KeyboardManager.swift
+++ b/Sources/Core/KeyboardManager.swift
@@ -28,6 +28,30 @@ class KeyboardManager {
             print("Failed to set the layout \"\(layoutID)\".")
         }
     }
+    
+    func selectLayout(withSource keyboardSource: KeyboardSource) {
+        if TISSelectInputSource(keyboardSource.source) != noErr {
+            print("Failed to set the layout \"\(keyboardSource.localizedName)\".")
+        } else {
+            print("Successfully set the layout \"\(keyboardSource.localizedName)\".")
+        }
+    }
+    
+    func enableLayout(withSource keyboardSource: KeyboardSource) {
+        if TISEnableInputSource(keyboardSource.source) != noErr {
+            print("Failed to enable the layout \"\(keyboardSource.localizedName)\".")
+        } else {
+            print("Successfully enabled the layout \"\(keyboardSource.localizedName)\".")
+        }
+    }
+    
+    func disableLayout(withSource keyboardSource: KeyboardSource) {
+        if TISDisableInputSource(keyboardSource.source) != noErr {
+            print("Failed to disable the layout \"\(keyboardSource.localizedName)\".")
+        } else {
+            print("Successfully disabled the layout \"\(keyboardSource.localizedName)\".")
+        }
+    }
 
     private func sourceList(includeAllInstalled: Bool) -> [KeyboardSource] {
         keyboardLayoutInputSources(includeAllInstalled: includeAllInstalled) + inputModeInputSources(includeAllInstalled: includeAllInstalled)


### PR DESCRIPTION
First off, thank you for making this tool, using it as part of a macOS ansible setup playbook. I noticed from the README that needing to add layouts manually first was a known limitation.

> To successfully execute the "select" command, the desired keyboard layout must be added in the macOS Settings app under Keyboard > Sources.

So made changes on my fork to allow enabling and disabling of keyboard layouts programmatically for my use case and thought I'd raise in case you think this could be a useful addition more generally.